### PR TITLE
[FIX] 기존 회원 재로그인시 토큰 중복 저장되는 부분 수정 (#167)

### DIFF
--- a/src/main/java/com/memorytrace/service/UserService.java
+++ b/src/main/java/com/memorytrace/service/UserService.java
@@ -37,8 +37,7 @@ public class UserService {
             return null;
         }
         if (request.getToken() != null &&
-            fcmTokenRepository.findByTokenAndUser_uid(request.getToken(), user.getUid())
-                .isEmpty()) {
+            fcmTokenRepository.findByTokenAndUser_uid(request.getToken(), user.getUid()) == null) {
             fcmTokenRepository
                 .save(FcmToken.builder().user(user).token(request.getToken()).build());
         }


### PR DESCRIPTION
### 🧐 이슈 번호
- close #167 
</br>

### 🛠 구현 사항
- 기존 회원 재로그인시 토큰 중복 저장되는 부분 수정 (isEmpty를 null로 수정)
</br>

### 📚 기타
</br>
