### PR TITLE
일기장을 탈퇴한 회원이 생긴 후에 초대하면 turnNo 중복되는 문제 수정

### DIFF
--- a/src/main/java/com/memorytrace/service/InviteService.java
+++ b/src/main/java/com/memorytrace/service/InviteService.java
@@ -55,7 +55,7 @@ public class InviteService {
             List<UserBook> userBook = userBookRepository
                 .findByBidAndIsWithdrawalOrderByTurnNo(book.getBid(), (byte) 0);
 
-            final int nowTurn = userBook.size();
+            final int nowTurn = (userBook.get(userBook.size() - 1).getTurnNo()) + 1;
 
             userBookRepository.save(UserBook.builder()
                 .bid(book.getBid())
@@ -69,7 +69,7 @@ public class InviteService {
             // TODO: 자신 제외 나머지 사람들에게 초대사람 완료 알림
             firebaseMessagingService.sendMulticast(
                 Message.builder().subject(book.getTitle())
-                    .content("새로운 멤버 "+ user.getNickname() + "님을 환영해주세요! ")
+                    .content("새로운 멤버 " + user.getNickname() + "님을 환영해주세요! ")
                     .data(book).build(),
                 fcmTokenRepository.findTokenBidAndUidNotInMe(book.getBid(), uid));
         } catch (Exception e) {


### PR DESCRIPTION
### 🧐 이슈 번호
- close #175 
</br>

### 🛠 구현 사항
- 일기장을 탈퇴한 회원이 생긴 후에 초대하면 turnNo 중복되는 문제 수정
  - 기존에 size()로 새로운 turnNo를 부여했는데, 실제 마지막 turnNo를 가져와서 + 1하도록 수정
</br>

### 📚 기타
</br>
