### PR TITLE
[FIX] Comment에 삭제여부 컬럼 추가 후 기존 API 수정 (#232)

### DIFF
--- a/src/main/java/com/memorytrace/domain/Comment.java
+++ b/src/main/java/com/memorytrace/domain/Comment.java
@@ -35,15 +35,20 @@ public class Comment extends BaseTimeEntity {
     @Column(length = 2000)
     private String content;
 
+    @Column(columnDefinition = "TINYINT DEFAULT 0", nullable = false)
+    private Byte isDelete;
+
     @Builder
-    public Comment(Long parent, User user, Diary diary, String content) {
+    public Comment(Long parent, User user, Diary diary, String content, Byte isDelete) {
         this.parent = parent;
         this.user = user;
         this.diary = diary;
         this.content = content;
+        this.isDelete = isDelete;
     }
 
     public void delete() {
         this.content = "삭제된 댓글입니다.";
+        this.isDelete = 1;
     }
 }

--- a/src/main/java/com/memorytrace/dto/response/CommentListResponseDto.java
+++ b/src/main/java/com/memorytrace/dto/response/CommentListResponseDto.java
@@ -26,7 +26,10 @@ public class CommentListResponseDto {
     @ApiModelProperty(position = 4, required = true, value = "댓글 작성 시간")
     private String createdDate;
 
-    @ApiModelProperty(position = 5, required = true, value = "대댓글 리스트")
+    @ApiModelProperty(position = 5, required = true, value = "삭제 여부")
+    private Byte isDelete;
+
+    @ApiModelProperty(position = 6, required = true, value = "대댓글 리스트")
     private List<CommentList> commentList = new ArrayList<>();
 
     @Getter
@@ -44,11 +47,15 @@ public class CommentListResponseDto {
         @ApiModelProperty(position = 4, required = true, value = "댓글 작성 시간")
         private String createdDate;
 
+        @ApiModelProperty(position = 5, required = true, value = "삭제 여부")
+        private Byte isDelete;
+
         public CommentList(Comment entity) {
             this.cid = entity.getCid();
             this.nickname = entity.getUser().getNickname();
             this.content = entity.getContent();
             this.createdDate = new PrettyTime().format(entity.getCreatedDate());
+            this.isDelete = entity.getIsDelete();
         }
     }
 
@@ -57,6 +64,7 @@ public class CommentListResponseDto {
         this.nickname = comment.getUser().getNickname();
         this.content = comment.getContent();
         this.createdDate = new PrettyTime().format(comment.getCreatedDate());
+        this.isDelete = comment.getIsDelete();
         this.commentList = commentList;
     }
 }


### PR DESCRIPTION
### 🧐 이슈 번호
- close #232 
</br>

### 🛠 구현 사항
- Comment domain에 isDelete 추가
- 추가는 default 0이라서 수정하지 않음
- 조회시 isDelete 같이 보내줌
- 삭제시 isDelete 1로 변경
</br>

### 📚 기타
⭐⭐⭐ 배포할 때 실제 DB에 is_delete 컬럼 추가하고 배포해주세요!
`ALTER TABLE comment ADD COLUMN is_delete tinyint(4) NOT NULL DEFAULT 0;`
</br>
